### PR TITLE
fix athena workgroup kms_key_arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 [![README Footer][readme_footer_img]][readme_footer_link]
 [![Beacon][beacon]][website]
-
+<!-- markdownlint-disable -->
   [logo]: https://cloudposse.com/logo-300x69.svg
   [docs]: https://cpco.io/docs?utm_source=github&utm_medium=readme&utm_campaign=%!!(string=docs)s(<nil>)&utm_content=%!s(MISSING)
   [website]: https://cpco.io/homepage?utm_source=github&utm_medium=readme&utm_campaign=%!!(string=website)s(<nil>)&utm_content=%!s(MISSING)
@@ -412,3 +412,4 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
   [share_googleplus]: https://plus.google.com/share?url=https://github.com/%!s(<nil>)
   [share_email]: mailto:?subject=terraform-aws-athena&body=https://github.com/%!s(<nil>)
   [beacon]: https://ga-beacon.cloudposse.com/UA-76589703-4/%!s(<nil>)?pixel&cs=github&cm=readme&an=nil
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@ locals {
   enabled = module.this.enabled
 
   s3_bucket_id = var.create_s3_bucket ? try(aws_s3_bucket.default[0].id, null) : var.athena_s3_bucket_id
+  kms_key_arn  = var.create_kms_key ? try(aws_kms_key.default[0].arn, null) : var.athena_kms_key
 }
 
 resource "aws_s3_bucket" "default" {
@@ -34,7 +35,7 @@ resource "aws_athena_workgroup" "default" {
     result_configuration {
       encryption_configuration {
         encryption_option = var.workgroup_encryption_option
-        kms_key_arn       = aws_kms_key.default[0].arn
+        kms_key_arn       = local.kms_key_arn
       }
       output_location = format("s3://%s/%s", local.s3_bucket_id, var.s3_output_path)
     }


### PR DESCRIPTION
## what
* Fixed encryption configuration on aws athena workgroup to properly use kms key created by this module if ```create_kms_key = true``` or to use value given to ```var.athena_kms_key``` if ```create_kms_key = true```.

## why
* The code was using the kms_key created by this module, regardless of value given to ```create_kms_key```.
* When trying to use this module and set a kms_key created outside of this module to the athena workgroup - it generates an error (shown below) because it tries to use the output of resource "aws_kms_key" from inside this module, which wasn't created because ```create_kms_key``` was set to ```false```.

Error generated before this fix:

```
 Error: Invalid index
 
   on .terraform/modules/this.athena/main.tf line 37, in resource "aws_athena_workgroup" "default":
   37:         kms_key_arn       = aws_kms_key.default[0].arn
     ├────────────────
     │ aws_kms_key.default is empty tuple
 
 The given key does not identify an element in this collection value: the collection has no elements.
```

## references




