### PR TITLE
fix: query argument only expect a query, not a database name

### DIFF
--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -10,6 +10,7 @@ jobs:
     steps:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
+      # Leave pinned at 0.7.1 until https://github.com/mszostok/codeowners-validator/issues/173 is resolved
     - uses: mszostok/codeowners-validator@v0.7.1
       if: github.event.pull_request.head.repo.full_name == github.repository
       name: "Full check of CODEOWNERS"

--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,6 @@ resource "aws_athena_named_query" "default" {
   name        = "${module.this.id}-${each.key}"
   workgroup   = aws_athena_workgroup.default[0].id
   database    = aws_athena_database.default[each.value.database].name
-  query       = format(each.value.query, each.value.database)
+  query       = each.value.query
   description = each.value.description
 }


### PR DESCRIPTION
## what
* fix a syntax error in aws_athena_named_query resource

## why
* For now the module fail with the following error when using named queries : 

```
Error: Invalid function argument

  on .terraform/modules/log-archive.athena/main.tf line 98, in resource "aws_athena_named_query" "default":
  98:   query       = format(each.value.query, each.value.database)
    ├────────────────
    │ while calling format(format, args...)
    │ each.value.database is "xxxx"

Invalid value for "args" parameter: too many arguments; no verbs in format string.
```

## references

